### PR TITLE
fix: bump boto3 and chalice dependency versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,9 +5,22 @@ ARG VARIANT="3"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
+ARG INSTALL_NODE
+ARG NODE_VERSION
+ARG TERRAFORM_VERSION
+ARG TERRAGRUNT_VERSION
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install Terraform
+RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/"${TERRAFORM_VERSION}"/terraform_"${TERRAFORM_VERSION}"_linux_amd64.zip \
+    && unzip terraform.zip \
+    && mv terraform /usr/local/bin/ \
+    && rm terraform.zip
+
+# Install Terragrunt
+RUN curl -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v"${TERRAGRUNT_VERSION}"/terragrunt_linux_amd64 \
+    && chmod +x terragrunt \
+    && mv terragrunt /usr/local/bin/
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,9 @@
 			"VARIANT": "3.8",
 			// Options
 			"INSTALL_NODE": "true",
-			"NODE_VERSION": "lts/*"
+			"NODE_VERSION": "lts/*",
+			"TERRAFORM_VERSION": "0.13.5",
+			"TERRAGRUNT_VERSION": "0.26.0",
 		}
 	},
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 babel==2.9.1
 black==20.8b1 
-chalice==1.21.6 
+chalice==1.26.0
 flake8==3.8.4
 pytest==6.2.1

--- a/secret/requirements.txt
+++ b/secret/requirements.txt
@@ -1,4 +1,4 @@
- aws-lambda-powertools==1.9.1
- boto3==1.16.38 
+aws-lambda-powertools==1.9.1
+boto3==1.18.61 
 cryptography==3.3.2
 jinja2==2.11.3 


### PR DESCRIPTION
# Summary
1. Bump version of `boto3` and `chalice` to fix a Lambda invocation error:
```sh
[ERROR] Runtime.ImportModuleError: Unable to import module 'app': libffi.so.7: cannot open shared object file: No such file or directory
Traceback (most recent call last):
```
2. Add Terraform/Terragrunt to the devcontainer.

⚠️ &nbsp; Change was applied locally to fix the service.