### PR TITLE
chore: switch AWS creds to OIDC roles

### DIFF
--- a/.github/workflows/merge_to_main.yaml
+++ b/.github/workflows/merge_to_main.yaml
@@ -8,15 +8,17 @@ on:
       - "aws/**"
       - "secret/**"
       - "terragrunt/**"
-      - ".github/workflows/**"
+      - ".github/workflows/merge_to_main.yaml"
 
 defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 0.13.5
   TERRAGRUNT_VERSION: 0.26.0
@@ -32,6 +34,13 @@ jobs:
 
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::637287734259:role/secret-apply
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Apply aws/acm
         working-directory: terragrunt/acm

--- a/.github/workflows/pull_requests_terraform.yml
+++ b/.github/workflows/pull_requests_terraform.yml
@@ -5,15 +5,18 @@ on:
     paths:
       - "aws/**"
       - "terragrunt/**"
-      - ".github/workflows/**"
+      - ".github/workflows/pull_requests_terraform.yml"
 
 defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   CONFTEST_VERSION: 0.27.0
   TERRAFORM_VERSION: 0.13.5
@@ -31,6 +34,13 @@ jobs:
 
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::637287734259:role/secret-plan
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Plan aws/acm
         uses: cds-snc/terraform-plan@28d2efe5155573489fa5b5816fad20d44d1f274b # v3.0.7


### PR DESCRIPTION
# Summary
Update the Terraform PR and push workflows to use
OIDC roles for their AWS credentials.

# Related
- https://github.com/cds-snc/platform-core-services/issues/512