### PR TITLE
feat: adds /version endpoint with Git SHA env variable

### DIFF
--- a/app.go
+++ b/app.go
@@ -42,6 +42,17 @@ func CreateApp(encryption encryption.EncryptionBackend, storage storage.StorageB
 		}, "base")
 	})
 
+	app.Get("/version", func(c *fiber.Ctx) error {
+		version := os.Getenv("GIT_SHA")
+		if version == "" {
+			version = "dev"
+		}
+
+		return c.JSON(fiber.Map{
+			"version": version,
+		})
+	})
+
 	app.Get("/:language", func(c *fiber.Ctx) error {
 		return c.Render("index", fiber.Map{
 			"Lang":      c.Params("language"),


### PR DESCRIPTION
Closes #31 by adding a `/version` endpoint. It will show the Git SHA of the version deployed, or `dev` if the `GIT_SHA` env variable is not set.