### PR TITLE
fix: secret retrieval is done by the `/decrypt` path

### DIFF
--- a/aws/lambda/cloudfront.tf
+++ b/aws/lambda/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "api" {
 
   # Prevent caching of displaying the secret
   ordered_cache_behavior {
-    path_pattern    = "/*/view/*"
+    path_pattern    = "/decrypt/*"
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods  = ["GET", "HEAD"]
 


### PR DESCRIPTION
# Summary
Update the CloudFront cache behaviour to prevent caching of the `/decrypt` path.