### PR TITLE
fix: use os.ReadFile to solve leaking files problem in loadLocales

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -212,12 +211,10 @@ func loadLocales() map[string]map[string]string {
 		translations[locale] = make(map[string]string)
 		file := fmt.Sprintf("./locales/%s.json", locale)
 
-		jsonFile, err := os.Open(file)
+		byteValue, err := os.ReadFile(file)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		byteValue, _ := io.ReadAll(jsonFile)
 
 		var result map[string]interface{}
 		json.Unmarshal([]byte(byteValue), &result)


### PR DESCRIPTION
This change fixes the leaking files problem in loadLocales by invoking os.ReadFile (introduced in Go1.16) which is much shorter than the previous patterns and doesn't leak resources.

Fixes #89