### PR TITLE
fix: upgrade deprecated Python Lambda runtime

### DIFF
--- a/aws/lambda/lambda-warmer.tf
+++ b/aws/lambda/lambda-warmer.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "lambda-warmer" {
   handler          = "lambda-warmer.handler"
   memory_size      = 128
   role             = aws_iam_role.lambda-iam-role.arn
-  runtime          = "python3.8"
+  runtime          = "python3.12"
   source_code_hash = data.archive_file.lambda-warmer.output_base64sha256
   timeout          = 60
 


### PR DESCRIPTION
# Summary
Upgrade to Python 3.12 Lambda runtime.

# Related
- https://github.com/cds-snc/platform-core-services/issues/560