### PR TITLE
fix: limit function invoke to CloudFront

### DIFF
--- a/aws/lambda/lambda.tf
+++ b/aws/lambda/lambda.tf
@@ -66,12 +66,14 @@ resource "aws_lambda_permission" "api_invoke_function_url" {
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = module.api.function_name
   function_url_auth_type = "NONE"
-  principal              = "*"
+  principal              = "cloudfront.amazonaws.com"
+  source_arn             = aws_cloudfront_distribution.api.arn
 }
 
 resource "aws_lambda_permission" "api_invoke_function" {
   statement_id  = "AllowInvokeFunction"
   action        = "lambda:InvokeFunction"
   function_name = module.api.function_name
-  principal     = "*"
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = aws_cloudfront_distribution.api.arn
 }


### PR DESCRIPTION
# Summary
Update the Terraform so that only CloudFront is able to invoke the function.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1015