### PR TITLE
feat: atomic secrets claim

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,22 +6,17 @@
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
 	},
-	"features": {
+		"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {
 			"version": "2.2.29"
-		},
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"terraform": {
-			"version": "1.3.8",
-			"tflint": "latest",
-			"terragrunt": "0.43.2"
-		},
+		}
 	},
 	"extensions": [
 		"redhat.vscode-yaml",
 		"github.copilot",
 		"golang.Go"
 	],
+	
 	"remoteUser": "vscode",
 	"postCreateCommand": ".devcontainer/dynamodb-local-create.sh",
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     depends_on:
       - dynamodb-local
       - local-kms
-    image: "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye@sha256:d7a51293c5f6526ac8c3e6fe41f567067d05311f644cd6bdc19355f952dc0776"
+    image: "mcr.microsoft.com/devcontainers/go:1.26-bookworm@sha256:1a3df7e2f24378acfb7c1048b7b018813112f280f011bad4aa9b02fff600481e"
     volumes:
       - ..:/workspace:cached
     command: sleep infinity

--- a/app.go
+++ b/app.go
@@ -19,6 +19,10 @@ import (
 const MAX_AGE_IN_DAYS = 7
 const MAX_SECRET_LENGTH = 64_000
 
+// Keep the claim lease longer than the deployed Lambda's 60-second timeout so
+// a request cannot lose its claim while it is still able to return a response.
+const SECRET_CLAIM_LEASE = 90 * time.Second
+
 type AppConfig struct {
 	RequireAdditionalPassword bool
 }
@@ -112,26 +116,36 @@ Preferred-Languages: en, fr`
 			return c.Status(fiber.StatusBadRequest).SendString("Invalid UUID")
 		}
 
-		//Get the encrypted data from the storage backend
-		encryptedData, key, err := storage.Retrieve(id)
+		// Atomically reserve the secret so concurrent requests cannot both decrypt it.
+		claimedSecret, err := storage.Claim(id, SECRET_CLAIM_LEASE)
 		if err != nil {
 			log.Warn(err)
 			return c.Status(fiber.StatusBadRequest).SendString("Invalid UUID")
 		}
 
+		claimActive := true
+		defer func() {
+			if claimActive {
+				if releaseErr := storage.Release(id, claimedSecret.Token); releaseErr != nil {
+					log.Error(releaseErr)
+				}
+			}
+		}()
+
 		//Decrypt the data
-		decryptedData, err := encryption.Decrypt(encryptedData, key)
+		decryptedData, err := encryption.Decrypt(claimedSecret.Data, claimedSecret.Key)
 		if err != nil {
 			log.Error(err)
 			return c.Status(fiber.StatusBadRequest).SendString("Invalid UUID")
 		}
 
-		//Delete the data from the storage backend
-		err = storage.Delete(id)
+		// Consume only the claim owned by this request before revealing the secret.
+		err = storage.Consume(id, claimedSecret.Token)
 		if err != nil {
 			log.Error(err)
 			return c.Status(fiber.StatusBadRequest).SendString("Invalid UUID")
 		}
+		claimActive = false
 
 		// Return a JSON response with the decrypted data
 		return c.JSON(fiber.Map{

--- a/app_test.go
+++ b/app_test.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +16,25 @@ import (
 	"github.com/cds-snc/secret/storage"
 	"github.com/gofiber/fiber/v2"
 )
+
+type failOnceEncryption struct {
+	failed atomic.Bool
+}
+
+func (e *failOnceEncryption) Init(map[string]string) error {
+	return nil
+}
+
+func (e *failOnceEncryption) Encrypt(plaintext []byte) ([]byte, []byte, error) {
+	return plaintext, nil, nil
+}
+
+func (e *failOnceEncryption) Decrypt(ciphertext, _ []byte) ([]byte, error) {
+	if e.failed.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("transient decryption failure")
+	}
+	return ciphertext, nil
+}
 
 func TestCreateApp(t *testing.T) {
 	t.Parallel()
@@ -315,12 +337,12 @@ func TestCreateAppGetDecryptWithIvalidUUID(t *testing.T) {
 func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 	t.Parallel()
 
-	storage := &storage.InMemoryStorageBackend{}
-	storage.Init(map[string]string{})
+	backend := &storage.InMemoryStorageBackend{}
+	backend.Init(map[string]string{})
 
-	id, _ := storage.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
 
-	app := CreateApp(&encryption.NullEncryption{}, storage)
+	app := CreateApp(&encryption.NullEncryption{}, backend)
 
 	req := httptest.NewRequest("GET", "/decrypt/"+id.String(), nil)
 	resp, _ := app.Test(req)
@@ -337,9 +359,87 @@ func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 	}
 
 	// Check if the data was deleted from the storage backend
-	_, _, err := storage.Retrieve(id)
-	if err == nil {
-		t.Errorf("CreateApp() GET /decrypt/valid-uuid = %v, want %v", err, "error")
+	_, err := backend.Claim(id, time.Minute)
+	if !errors.Is(err, storage.ErrSecretUnavailable) {
+		t.Errorf("Claim() after decrypt = %v, want ErrSecretUnavailable", err)
+	}
+}
+
+func TestCreateAppConcurrentDecryptHasExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+
+	backend := &storage.InMemoryStorageBackend{}
+	if err := backend.Init(map[string]string{}); err != nil {
+		t.Fatalf("Init() failed: %v", err)
+	}
+	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix())
+	if err != nil {
+		t.Fatalf("Store() failed: %v", err)
+	}
+
+	app := CreateApp(&encryption.NullEncryption{}, backend)
+	const contenders = 32
+	start := make(chan struct{})
+	statuses := make(chan int, contenders)
+	var wg sync.WaitGroup
+
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			req := httptest.NewRequest("GET", "/decrypt/"+id.String(), nil)
+			resp, requestErr := app.Test(req)
+			if requestErr != nil {
+				t.Errorf("GET /decrypt returned an error: %v", requestErr)
+				return
+			}
+			statuses <- resp.StatusCode
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(statuses)
+
+	successes := 0
+	for status := range statuses {
+		if status == fiber.StatusOK {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful concurrent decryptions = %d, want exactly 1", successes)
+	}
+}
+
+func TestCreateAppReleasesClaimAfterDecryptionFailure(t *testing.T) {
+	t.Parallel()
+
+	backend := &storage.InMemoryStorageBackend{}
+	if err := backend.Init(map[string]string{}); err != nil {
+		t.Fatalf("Init() failed: %v", err)
+	}
+	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix())
+	if err != nil {
+		t.Fatalf("Store() failed: %v", err)
+	}
+
+	app := CreateApp(&failOnceEncryption{}, backend)
+	first, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	if first.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("first decrypt status = %d, want %d", first.StatusCode, fiber.StatusBadRequest)
+	}
+
+	second, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	if second.StatusCode != fiber.StatusOK {
+		t.Fatalf("retry decrypt status = %d, want %d", second.StatusCode, fiber.StatusOK)
+	}
+
+	third, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	if third.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("decrypt after successful retry status = %d, want %d", third.StatusCode, fiber.StatusBadRequest)
 	}
 }
 
@@ -359,12 +459,12 @@ func TestCreateAppDeleteInvalidUUID(t *testing.T) {
 func TestCreateAppDeleteValidUUID(t *testing.T) {
 	t.Parallel()
 
-	storage := &storage.InMemoryStorageBackend{}
-	storage.Init(map[string]string{})
+	backend := &storage.InMemoryStorageBackend{}
+	backend.Init(map[string]string{})
 
-	id, _ := storage.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
 
-	app := CreateApp(&encryption.NullEncryption{}, storage)
+	app := CreateApp(&encryption.NullEncryption{}, backend)
 
 	req := httptest.NewRequest("DELETE", "/delete/"+id.String(), nil)
 	resp, _ := app.Test(req)
@@ -381,9 +481,9 @@ func TestCreateAppDeleteValidUUID(t *testing.T) {
 	}
 
 	// Check if the data was deleted from the storage backend
-	_, _, err := storage.Retrieve(id)
-	if err == nil {
-		t.Errorf("CreateApp() DELETE /delete/valid-uuid = %v, want %v", err, "error")
+	_, err := backend.Claim(id, time.Minute)
+	if !errors.Is(err, storage.ErrSecretUnavailable) {
+		t.Errorf("Claim() after delete = %v, want ErrSecretUnavailable", err)
 	}
 }
 

--- a/storage/dynamodb.go
+++ b/storage/dynamodb.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,10 +15,12 @@ import (
 )
 
 type Record struct {
-	ID   string `dynamodbav:"id"`
-	Data []byte `dynamodbav:"data"`
-	Key  []byte `dynamodbav:"key"`
-	TTL  int64  `dynamodbav:"ttl"`
+	ID         string `dynamodbav:"id"`
+	Data       []byte `dynamodbav:"data"`
+	Key        []byte `dynamodbav:"key"`
+	TTL        int64  `dynamodbav:"ttl"`
+	ClaimToken string `dynamodbav:"claim_token,omitempty"`
+	ClaimUntil int64  `dynamodbav:"claim_until,omitempty"`
 }
 
 type DynamoDBBackend struct {
@@ -121,35 +124,109 @@ func (b *DynamoDBBackend) Store(data, key []byte, ttl int64) (uuid.UUID, error) 
 	return id, nil
 }
 
-func (b *DynamoDBBackend) Retrieve(id uuid.UUID) ([]byte, []byte, error) {
-	record, err := b.client.GetItem(context.TODO(), &dynamodb.GetItemInput{
+// Claim atomically reserves an unclaimed or abandoned secret and returns its data.
+func (b *DynamoDBBackend) Claim(id uuid.UUID, lease time.Duration) (ClaimedSecret, error) {
+	if lease <= 0 {
+		return ClaimedSecret{}, fmt.Errorf("claim lease must be positive")
+	}
+
+	now := time.Now()
+	token := uuid.New()
+	updateExpression := "SET #claim_token = :claim_token, #claim_until = :claim_until"
+	conditionExpression := "attribute_exists(#id) AND #ttl >= :now AND (attribute_not_exists(#claim_until) OR #claim_until <= :now)"
+	record, err := b.client.UpdateItem(context.TODO(), &dynamodb.UpdateItemInput{
 		Key: map[string]types.AttributeValue{
 			"id": &types.AttributeValueMemberS{Value: id.String()},
 		},
-		TableName: &b.table_name,
+		TableName:           &b.table_name,
+		UpdateExpression:    &updateExpression,
+		ConditionExpression: &conditionExpression,
+		ExpressionAttributeNames: map[string]string{
+			"#id":          "id",
+			"#ttl":         "ttl",
+			"#claim_token": "claim_token",
+			"#claim_until": "claim_until",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":now":         &types.AttributeValueMemberN{Value: fmt.Sprint(now.Unix())},
+			":claim_token": &types.AttributeValueMemberS{Value: token.String()},
+			":claim_until": &types.AttributeValueMemberN{Value: fmt.Sprint(now.Add(lease).Unix())},
+		},
+		ReturnValues: types.ReturnValueAllNew,
 	})
 
 	if err != nil {
-		return nil, nil, err
+		if isConditionalCheckFailed(err) {
+			return ClaimedSecret{}, ErrSecretUnavailable
+		}
+		return ClaimedSecret{}, err
 	}
 
-	if record.Item == nil {
-		return nil, nil, nil
+	if record.Attributes == nil {
+		return ClaimedSecret{}, ErrSecretUnavailable
 	}
 
 	var r Record
-
-	err = attributevalue.UnmarshalMap(record.Item, &r)
-
+	err = attributevalue.UnmarshalMap(record.Attributes, &r)
 	if err != nil {
-		return nil, nil, err
+		return ClaimedSecret{}, err
 	}
 
-	// Check if TTL timestamp is less than current unix time
-	if r.TTL < time.Now().Unix() {
-		b.Delete(id)
-		return nil, nil, fmt.Errorf("UUID not found")
-	}
+	return ClaimedSecret{Data: r.Data, Key: r.Key, Token: token}, nil
+}
 
-	return r.Data, r.Key, nil
+// Consume permanently deletes a secret if the caller still owns an active claim.
+func (b *DynamoDBBackend) Consume(id, token uuid.UUID) error {
+	conditionExpression := "#claim_token = :claim_token AND #claim_until > :now"
+	_, err := b.client.DeleteItem(context.TODO(), &dynamodb.DeleteItemInput{
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: id.String()},
+		},
+		TableName:           &b.table_name,
+		ConditionExpression: &conditionExpression,
+		ExpressionAttributeNames: map[string]string{
+			"#claim_token": "claim_token",
+			"#claim_until": "claim_until",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":claim_token": &types.AttributeValueMemberS{Value: token.String()},
+			":now":         &types.AttributeValueMemberN{Value: fmt.Sprint(time.Now().Unix())},
+		},
+	})
+
+	if isConditionalCheckFailed(err) {
+		return ErrClaimLost
+	}
+	return err
+}
+
+// Release clears a claim if the caller still owns it, allowing an immediate retry.
+func (b *DynamoDBBackend) Release(id, token uuid.UUID) error {
+	updateExpression := "REMOVE #claim_token, #claim_until"
+	conditionExpression := "#claim_token = :claim_token"
+	_, err := b.client.UpdateItem(context.TODO(), &dynamodb.UpdateItemInput{
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: id.String()},
+		},
+		TableName:           &b.table_name,
+		UpdateExpression:    &updateExpression,
+		ConditionExpression: &conditionExpression,
+		ExpressionAttributeNames: map[string]string{
+			"#claim_token": "claim_token",
+			"#claim_until": "claim_until",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":claim_token": &types.AttributeValueMemberS{Value: token.String()},
+		},
+	})
+
+	if isConditionalCheckFailed(err) {
+		return ErrClaimLost
+	}
+	return err
+}
+
+func isConditionalCheckFailed(err error) bool {
+	var conditionFailed *types.ConditionalCheckFailedException
+	return errors.As(err, &conditionFailed)
 }

--- a/storage/dynamodb_test.go
+++ b/storage/dynamodb_test.go
@@ -1,7 +1,10 @@
 package storage
 
 import (
+	"errors"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -135,7 +138,7 @@ func TestDynamoDBBackendStore(t *testing.T) {
 	}
 }
 
-func TestDynamoDBBackendRetrieveWithTTLInFuture(t *testing.T) {
+func TestDynamoDBBackendClaimAndConsume(t *testing.T) {
 	t.Parallel()
 
 	backend := DynamoDBBackend{}
@@ -152,22 +155,29 @@ func TestDynamoDBBackendRetrieveWithTTLInFuture(t *testing.T) {
 		t.Errorf("DynamoDBBackend.Store() failed: %s", err)
 	}
 
-	data, key, err := backend.Retrieve(id)
+	claim, err := backend.Claim(id, time.Minute)
 
 	if err != nil {
-		t.Errorf("DynamoDBBackend.Retrieve() failed: %s", err)
+		t.Fatalf("DynamoDBBackend.Claim() failed: %s", err)
 	}
 
-	if string(data) != "test" {
-		t.Errorf("DynamoDBBackend.Retrieve() returned the wrong data")
+	if string(claim.Data) != "test" {
+		t.Errorf("DynamoDBBackend.Claim() returned the wrong data")
 	}
 
-	if string(key) != "key" {
-		t.Errorf("DynamoDBBackend.Retrieve() returned the wrong key")
+	if string(claim.Key) != "key" {
+		t.Errorf("DynamoDBBackend.Claim() returned the wrong key")
+	}
+
+	if err := backend.Consume(id, claim.Token); err != nil {
+		t.Fatalf("DynamoDBBackend.Consume() failed: %s", err)
+	}
+	if _, err := backend.Claim(id, time.Minute); !errors.Is(err, ErrSecretUnavailable) {
+		t.Errorf("Claim() after Consume() = %v, want ErrSecretUnavailable", err)
 	}
 }
 
-func TestDynamoDBBackendRetrieveWithTTLInPast(t *testing.T) {
+func TestDynamoDBBackendClaimWithTTLInPast(t *testing.T) {
 	t.Parallel()
 
 	backend := DynamoDBBackend{}
@@ -184,9 +194,89 @@ func TestDynamoDBBackendRetrieveWithTTLInPast(t *testing.T) {
 		t.Errorf("DynamoDBBackend.Store() failed: %s", err)
 	}
 
-	_, _, err = backend.Retrieve(id)
+	_, err = backend.Claim(id, time.Minute)
 
-	if err == nil {
-		t.Errorf("DynamoDBBackend.Retrieve() should have failed")
+	if !errors.Is(err, ErrSecretUnavailable) {
+		t.Errorf("DynamoDBBackend.Claim() = %v, want ErrSecretUnavailable", err)
+	}
+}
+
+func TestDynamoDBBackendConcurrentClaimsHaveExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+
+	backend := DynamoDBBackend{}
+	_ = backend.Init(map[string]string{
+		"endpoint":   getDynamoDBHost,
+		"region":     "ca-central-1",
+		"table_name": "secrets",
+	})
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	if err != nil {
+		t.Fatalf("Store() failed: %v", err)
+	}
+
+	const contenders = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var winners atomic.Int32
+	tokens := make(chan uuid.UUID, contenders)
+
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			claim, claimErr := backend.Claim(id, time.Minute)
+			if claimErr == nil {
+				winners.Add(1)
+				tokens <- claim.Token
+				return
+			}
+			if !errors.Is(claimErr, ErrSecretUnavailable) {
+				t.Errorf("Claim() returned unexpected error: %v", claimErr)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(tokens)
+
+	if winners.Load() != 1 {
+		t.Fatalf("successful claims = %d, want exactly 1", winners.Load())
+	}
+	if err := backend.Consume(id, <-tokens); err != nil {
+		t.Fatalf("Consume() winning claim failed: %v", err)
+	}
+}
+
+func TestDynamoDBBackendReleaseAllowsRetry(t *testing.T) {
+	t.Parallel()
+
+	backend := DynamoDBBackend{}
+	_ = backend.Init(map[string]string{
+		"endpoint":   getDynamoDBHost,
+		"region":     "ca-central-1",
+		"table_name": "secrets",
+	})
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	if err != nil {
+		t.Fatalf("Store() failed: %v", err)
+	}
+
+	first, err := backend.Claim(id, time.Minute)
+	if err != nil {
+		t.Fatalf("first Claim() failed: %v", err)
+	}
+	if err := backend.Release(id, first.Token); err != nil {
+		t.Fatalf("Release() failed: %v", err)
+	}
+	second, err := backend.Claim(id, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim() after Release() failed: %v", err)
+	}
+	if second.Token == first.Token {
+		t.Fatal("Claim() after Release() reused the old token")
 	}
 }

--- a/storage/in_memory.go
+++ b/storage/in_memory.go
@@ -9,9 +9,11 @@ import (
 )
 
 type pair struct {
-	Data []byte
-	Key  []byte
-	TTL  int64
+	Data       []byte
+	Key        []byte
+	TTL        int64
+	ClaimToken uuid.UUID
+	ClaimUntil time.Time
 }
 
 // InMemoryStorageBackend is a storage backend that stores data in memory
@@ -49,15 +51,21 @@ func (b *InMemoryStorageBackend) Init(map[string]string) error {
 // The function itself may not be as efficient at it is O(n)
 // however, Go is fast enough to purge 100k+ entries in a few ms
 func (b *InMemoryStorageBackend) purge() error {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	for id, pair := range b.data {
 		if pair.TTL < time.Now().Unix() {
-			b.Delete(id)
+			delete(b.data, id)
 		}
 	}
 	return nil
 }
 
 func (b *InMemoryStorageBackend) size() int {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	return len(b.data)
 }
 
@@ -66,26 +74,73 @@ func (b *InMemoryStorageBackend) Store(data, key []byte, TTL int64) (uuid.UUID, 
 	b.m.Lock()
 	defer b.m.Unlock()
 
-	uuid := uuid.New()
-	b.data[uuid] = pair{Data: data, Key: key, TTL: TTL}
-	return uuid, nil
+	id := uuid.New()
+	b.data[id] = pair{Data: data, Key: key, TTL: TTL}
+	return id, nil
 }
 
-// Retrieve retrieves data from the storage backend
-func (b *InMemoryStorageBackend) Retrieve(id uuid.UUID) ([]byte, []byte, error) {
+// Claim atomically reserves a secret for a single consumer for the lease duration.
+func (b *InMemoryStorageBackend) Claim(id uuid.UUID, lease time.Duration) (ClaimedSecret, error) {
+	if lease <= 0 {
+		return ClaimedSecret{}, fmt.Errorf("claim lease must be positive")
+	}
+
 	b.m.Lock()
 	defer b.m.Unlock()
 
-	if _, ok := b.data[id]; ok {
-
-		// Check if TTL timestamp is less than current unix time
-		if b.data[id].TTL < time.Now().Unix() {
-			delete(b.data, id)
-			return nil, nil, fmt.Errorf("UUID not found")
-		}
-
-		return b.data[id].Data, b.data[id].Key, nil
+	secret, ok := b.data[id]
+	if !ok {
+		return ClaimedSecret{}, ErrSecretUnavailable
 	}
 
-	return nil, nil, fmt.Errorf("UUID not found")
+	now := time.Now()
+	if secret.TTL < now.Unix() {
+		delete(b.data, id)
+		return ClaimedSecret{}, ErrSecretUnavailable
+	}
+
+	if secret.ClaimToken != uuid.Nil && secret.ClaimUntil.After(now) {
+		return ClaimedSecret{}, ErrSecretUnavailable
+	}
+
+	token := uuid.New()
+	secret.ClaimToken = token
+	secret.ClaimUntil = now.Add(lease)
+	b.data[id] = secret
+
+	return ClaimedSecret{
+		Data:  append([]byte(nil), secret.Data...),
+		Key:   append([]byte(nil), secret.Key...),
+		Token: token,
+	}, nil
+}
+
+// Consume permanently deletes a secret if the caller still owns its claim.
+func (b *InMemoryStorageBackend) Consume(id, token uuid.UUID) error {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	secret, ok := b.data[id]
+	if !ok || secret.ClaimToken != token || !secret.ClaimUntil.After(time.Now()) {
+		return ErrClaimLost
+	}
+
+	delete(b.data, id)
+	return nil
+}
+
+// Release makes a claimed secret immediately available for another attempt.
+func (b *InMemoryStorageBackend) Release(id, token uuid.UUID) error {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	secret, ok := b.data[id]
+	if !ok || secret.ClaimToken != token {
+		return ErrClaimLost
+	}
+
+	secret.ClaimToken = uuid.Nil
+	secret.ClaimUntil = time.Time{}
+	b.data[id] = secret
+	return nil
 }

--- a/storage/in_memory_test.go
+++ b/storage/in_memory_test.go
@@ -1,102 +1,196 @@
 package storage
 
 import (
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+const testClaimLease = time.Minute
+
+func newInMemoryBackend(t *testing.T) *InMemoryStorageBackend {
+	t.Helper()
+
+	backend := &InMemoryStorageBackend{}
+	if err := backend.Init(map[string]string{}); err != nil {
+		t.Fatalf("InMemoryStorageBackend.Init() failed: %v", err)
+	}
+	return backend
+}
+
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	uuid, _ := backend.Store([]byte("data"), []byte("key"), 0)
-	err := backend.Delete(uuid)
-	if err != nil {
-		t.Error("Expected nil, got", err)
-	}
-	_, _, err = backend.Retrieve(uuid)
-	if err == nil {
-		t.Error("Expected error, got nil")
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	if err := backend.Delete(id); err != nil {
+		t.Fatalf("Delete() failed: %v", err)
 	}
 
+	if _, err := backend.Claim(id, testClaimLease); !errors.Is(err, ErrSecretUnavailable) {
+		t.Fatalf("Claim() after Delete() = %v, want ErrSecretUnavailable", err)
+	}
 }
 
 func TestInit(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	err := backend.Init(map[string]string{})
-	if err != nil {
-		t.Error("Expected nil, got", err)
+	backend := &InMemoryStorageBackend{}
+	if err := backend.Init(map[string]string{}); err != nil {
+		t.Fatalf("Init() failed: %v", err)
 	}
 }
 
 func TestPurge(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
-	backend.(*InMemoryStorageBackend).purge()
-	if backend.(*InMemoryStorageBackend).size() != 0 {
-		t.Error("Expected 0, got", backend.(*InMemoryStorageBackend).size())
+	backend := newInMemoryBackend(t)
+	_, _ = backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
+	if err := backend.purge(); err != nil {
+		t.Fatalf("purge() failed: %v", err)
+	}
+	if backend.size() != 0 {
+		t.Fatalf("size() = %d, want 0", backend.size())
 	}
 }
 
 func TestStore(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	uuid, err := backend.Store([]byte("data"), []byte("key"), 0)
+	backend := newInMemoryBackend(t)
+	id, err := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
 	if err != nil {
-		t.Error("Expected nil, got", err)
+		t.Fatalf("Store() failed: %v", err)
 	}
-	if uuid.String() == "" {
-		t.Error("Expected UUID, got empty string")
+	if id == uuid.Nil {
+		t.Fatal("Store() returned a nil UUID")
 	}
 }
 
-func TestRetrieveWithTTLInFuture(t *testing.T) {
+func TestClaimAndConsume(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	uuid, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
-	data, key, err := backend.Retrieve(uuid)
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+
+	claim, err := backend.Claim(id, testClaimLease)
 	if err != nil {
-		t.Error("Expected nil, got", err)
+		t.Fatalf("Claim() failed: %v", err)
 	}
-	if string(data) != "data" {
-		t.Error("Expected data, got", string(data))
+	if string(claim.Data) != "data" || string(claim.Key) != "key" || claim.Token == uuid.Nil {
+		t.Fatalf("Claim() returned an invalid claim: %#v", claim)
 	}
-	if string(key) != "key" {
-		t.Error("Expected key, got", string(key))
-	}
-}
 
-func TestRetrieveWithTTLInPast(t *testing.T) {
-	t.Parallel()
-
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	uuid, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
-	_, _, err := backend.Retrieve(uuid)
-	if err == nil {
-		t.Error("Expected error, got nil")
+	if err := backend.Consume(id, claim.Token); err != nil {
+		t.Fatalf("Consume() failed: %v", err)
+	}
+	if _, err := backend.Claim(id, testClaimLease); !errors.Is(err, ErrSecretUnavailable) {
+		t.Fatalf("Claim() after Consume() = %v, want ErrSecretUnavailable", err)
 	}
 }
 
-func TestRetrieveNotFound(t *testing.T) {
+func TestClaimExpiredOrMissingSecret(t *testing.T) {
 	t.Parallel()
 
-	var backend StorageBackend = &InMemoryStorageBackend{}
-	backend.Init(map[string]string{})
-	_, _, err := backend.Retrieve(uuid.Nil)
-	if err == nil {
-		t.Error("Expected error, got nil")
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
+
+	for _, testID := range []uuid.UUID{id, uuid.New()} {
+		if _, err := backend.Claim(testID, testClaimLease); !errors.Is(err, ErrSecretUnavailable) {
+			t.Fatalf("Claim(%s) = %v, want ErrSecretUnavailable", testID, err)
+		}
+	}
+}
+
+func TestConcurrentClaimsHaveExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+
+	const contenders = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var winners atomic.Int32
+	winnerTokens := make(chan uuid.UUID, contenders)
+
+	for range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			claim, err := backend.Claim(id, testClaimLease)
+			if err == nil {
+				winners.Add(1)
+				winnerTokens <- claim.Token
+				return
+			}
+			if !errors.Is(err, ErrSecretUnavailable) {
+				t.Errorf("Claim() returned unexpected error: %v", err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(winnerTokens)
+
+	if winners.Load() != 1 {
+		t.Fatalf("successful claims = %d, want exactly 1", winners.Load())
+	}
+	if err := backend.Consume(id, <-winnerTokens); err != nil {
+		t.Fatalf("Consume() winning claim failed: %v", err)
+	}
+}
+
+func TestReleaseAllowsImmediateRetry(t *testing.T) {
+	t.Parallel()
+
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+
+	first, err := backend.Claim(id, testClaimLease)
+	if err != nil {
+		t.Fatalf("first Claim() failed: %v", err)
+	}
+	if err := backend.Release(id, first.Token); err != nil {
+		t.Fatalf("Release() failed: %v", err)
+	}
+
+	second, err := backend.Claim(id, testClaimLease)
+	if err != nil {
+		t.Fatalf("Claim() after Release() failed: %v", err)
+	}
+	if second.Token == first.Token {
+		t.Fatal("Claim() after Release() reused the previous token")
+	}
+}
+
+func TestExpiredClaimCanBeReclaimed(t *testing.T) {
+	t.Parallel()
+
+	backend := newInMemoryBackend(t)
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+
+	first, err := backend.Claim(id, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("first Claim() failed: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	second, err := backend.Claim(id, testClaimLease)
+	if err != nil {
+		t.Fatalf("Claim() after lease expiry failed: %v", err)
+	}
+	if second.Token == first.Token {
+		t.Fatal("reclaimed secret reused the expired token")
+	}
+	if err := backend.Consume(id, first.Token); !errors.Is(err, ErrClaimLost) {
+		t.Fatalf("Consume() with expired token = %v, want ErrClaimLost", err)
 	}
 }

--- a/storage/null.go
+++ b/storage/null.go
@@ -1,12 +1,22 @@
 package storage
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
 // NullBackend is a storage backend that does nothing
 
 type NullBackend struct{}
+
+func (b *NullBackend) Claim(id uuid.UUID, lease time.Duration) (ClaimedSecret, error) {
+	return ClaimedSecret{}, ErrSecretUnavailable
+}
+
+func (b *NullBackend) Consume(id, token uuid.UUID) error {
+	return nil
+}
 
 func (b *NullBackend) Delete(id uuid.UUID) error {
 	return nil
@@ -20,6 +30,6 @@ func (b *NullBackend) Store(data, key []byte, ttl int64) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
 
-func (b *NullBackend) Retrieve(id uuid.UUID) ([]byte, []byte, error) {
-	return nil, nil, nil
+func (b *NullBackend) Release(id, token uuid.UUID) error {
+	return nil
 }

--- a/storage/null_test.go
+++ b/storage/null_test.go
@@ -1,7 +1,9 @@
 package storage
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -38,13 +40,27 @@ func TestNullBackendStore(t *testing.T) {
 	}
 }
 
-func TestNullBackendRetrieve(t *testing.T) {
+func TestNullBackendClaim(t *testing.T) {
 	t.Parallel()
 
 	backend := NullBackend{}
 	id := uuid.New()
-	_, _, err := backend.Retrieve(id)
-	if err != nil {
-		t.Errorf("expected no error, got %v", err)
+	_, err := backend.Claim(id, time.Minute)
+	if !errors.Is(err, ErrSecretUnavailable) {
+		t.Errorf("Claim() = %v, want ErrSecretUnavailable", err)
+	}
+}
+
+func TestNullBackendClaimLifecycle(t *testing.T) {
+	t.Parallel()
+
+	backend := NullBackend{}
+	id := uuid.New()
+	token := uuid.New()
+	if err := backend.Consume(id, token); err != nil {
+		t.Errorf("Consume() failed: %v", err)
+	}
+	if err := backend.Release(id, token); err != nil {
+		t.Errorf("Release() failed: %v", err)
 	}
 }

--- a/storage/storage_backend.go
+++ b/storage/storage_backend.go
@@ -1,10 +1,28 @@
 package storage
 
-import "github.com/google/uuid"
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrSecretUnavailable = errors.New("secret not found, expired, or already claimed")
+	ErrClaimLost         = errors.New("secret claim is no longer valid")
+)
+
+type ClaimedSecret struct {
+	Data  []byte
+	Key   []byte
+	Token uuid.UUID
+}
 
 type StorageBackend interface {
+	Claim(id uuid.UUID, lease time.Duration) (ClaimedSecret, error)
+	Consume(id, token uuid.UUID) error
 	Delete(id uuid.UUID) error
 	Init(map[string]string) error
+	Release(id, token uuid.UUID) error
 	Store(data, key []byte, ttl int64) (uuid.UUID, error)
-	Retrieve(id uuid.UUID) ([]byte, []byte, error)
 }


### PR DESCRIPTION
This pull request introduces a robust claim/consume/release mechanism for secrets, replacing the previous retrieve/delete pattern. The main goal is to ensure that only one concurrent request can access and consume a secret, improving atomicity and preventing race conditions. The changes span both the in-memory and DynamoDB storage backends, update the application logic, and add comprehensive tests for concurrency and error handling.

**Atomic claim/consume/release for secrets:**

* Added a `Claim` method to both the in-memory (`InMemoryStorageBackend`) and DynamoDB (`DynamoDBBackend`) backends that atomically reserves a secret for a single consumer, using a lease duration and claim token. Only one concurrent claim can succeed. (`[[1]](diffhunk://#diff-309bea73cd40c4586869d174a670b89bef098ce4e70b55182b1b8bd66c52bd0bL69-R145)`, `[[2]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L124-R231)`)
* Added a `Consume` method to both backends to permanently delete a secret, but only if the caller still owns the active claim. (`[[1]](diffhunk://#diff-309bea73cd40c4586869d174a670b89bef098ce4e70b55182b1b8bd66c52bd0bL69-R145)`, `[[2]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L124-R231)`)
* Added a `Release` method to both backends to clear a claim, allowing an immediate retry if decryption fails. (`[[1]](diffhunk://#diff-309bea73cd40c4586869d174a670b89bef098ce4e70b55182b1b8bd66c52bd0bL69-R145)`, `[[2]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L124-R231)`)

**Application logic updates:**

* Updated the `/decrypt/:id` endpoint to use the claim/consume/release flow: atomically claim the secret, attempt decryption, consume the secret if successful, or release the claim if decryption fails. This ensures only one request can decrypt and consume a secret, and failed attempts allow retries. (`[app.goL115-R148](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL115-R148)`)
* Introduced a `SECRET_CLAIM_LEASE` constant to control the claim duration, ensuring a request cannot lose its claim before completing. (`[app.goR22-R25](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR22-R25)`)

**Testing and validation:**

* Added and updated tests for both in-memory and DynamoDB backends to verify that only one concurrent claim can succeed, that claims are properly consumed or released, and that error scenarios (such as decryption failure or expired TTL) are handled correctly. (`[[1]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL340-R442)`, `[[2]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L138-R141)`, `[[3]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L155-R180)`, `[[4]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L187-R280)`)
* Added a test encryption implementation to simulate transient decryption failures and verify that claims are released for retries. (`[app_test.goR20-R38](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR20-R38)`)

**Internal code and test refactoring:**

* Refactored tests and backend code to use consistent naming (`backend` instead of `storage`), and improved thread safety in the in-memory backend by locking in `purge` and `size`. (`[[1]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL318-R345)`, `[[2]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL362-R467)`, `[[3]](diffhunk://#diff-309bea73cd40c4586869d174a670b89bef098ce4e70b55182b1b8bd66c52bd0bR54-R68)`)

**Schema and error handling updates:**

* Updated the DynamoDB record schema to include `claim_token` and `claim_until` fields, and improved error handling for claim-related operations. (`[[1]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2R22-R23)`, `[[2]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L124-R231)`)

These changes significantly improve the safety and reliability of secret consumption, especially under concurrent access.