### PR TITLE
feat: client side encryption detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The application uses a combination of AES-256 encryption and a unique URL to hid
 
 Optionally, you can also encrypt the message on the client side before sending it to the server. This means that the server never sees the unencrypted message. This is useful if you don't trust the server or if you want to add an extra layer of security. However, the recipient will need to know the password you used to encrypt the message in order to decrypt it.
 
-New password-protected messages use a versioned `emc:v2` envelope. The browser derives an encryption key with PBKDF2-HMAC-SHA-256 and encrypts the message with AES-256-GCM through the Web Crypto API. The password and derived key never leave the browser. The client temporarily retains decryption support for links created with the previous CryptoJS AES-CBC format; that compatibility path can be removed after the maximum seven-day lifetime of legacy links has passed.
+Password-protected messages use a versioned `emc:v2` envelope. The browser derives an encryption key with PBKDF2-HMAC-SHA-256 and encrypts the message with AES-256-GCM through the Web Crypto API. The password and derived key never leave the browser. Each new record also stores a non-secret marker indicating whether browser encryption was selected, so the password controls only appear when they are needed. CryptoJS AES-CBC links are no longer supported.
 
 ## Backends
 

--- a/app.go
+++ b/app.go
@@ -1,10 +1,13 @@
 package app
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -18,6 +21,8 @@ import (
 
 const MAX_AGE_IN_DAYS = 7
 const MAX_SECRET_LENGTH = 64_000
+const CLIENT_ENCRYPTION_PREFIX = "emc:v2:"
+const CLIENT_ENCRYPTION_ITERATIONS = 600_000
 
 // Keep the claim lease longer than the deployed Lambda's 60-second timeout so
 // a request cannot lose its claim while it is still able to return a response.
@@ -148,8 +153,14 @@ Preferred-Languages: en, fr`
 		claimActive = false
 
 		// Return a JSON response with the decrypted data
+		clientEncrypted := isClientEncryptionEnvelope(string(decryptedData))
+		if claimedSecret.ClientEncrypted != nil {
+			clientEncrypted = *claimedSecret.ClientEncrypted
+		}
+
 		return c.JSON(fiber.Map{
-			"body": string(decryptedData),
+			"body":             string(decryptedData),
+			"client_encrypted": clientEncrypted,
 		})
 	})
 
@@ -178,8 +189,9 @@ Preferred-Languages: en, fr`
 
 		// Parse the JSON body from the request
 		type RequestBody struct {
-			Body string `json:"body"`
-			TTL  int64  `json:"ttl"`
+			Body            string `json:"body"`
+			TTL             int64  `json:"ttl"`
+			ClientEncrypted bool   `json:"client_encrypted"`
 		}
 
 		var body RequestBody
@@ -190,7 +202,7 @@ Preferred-Languages: en, fr`
 		}
 
 		// Encrypt and save the data
-		id, err := encryptAndSave(body.Body, body.TTL, encryption, storage)
+		id, err := encryptAndSave(body.Body, body.TTL, body.ClientEncrypted, encryption, storage)
 
 		if err != nil {
 			log.Error(err)
@@ -206,7 +218,7 @@ Preferred-Languages: en, fr`
 	return app
 }
 
-func encryptAndSave(body string, ttl int64, encryption encryption.EncryptionBackend, storage storage.StorageBackend) (string, error) {
+func encryptAndSave(body string, ttl int64, clientEncrypted bool, encryption encryption.EncryptionBackend, storage storage.StorageBackend) (string, error) {
 	// Check the TTL is in range
 	currentTimestamp := time.Now().Unix()
 	if ttl < currentTimestamp || ttl > currentTimestamp+(MAX_AGE_IN_DAYS*24*60*60) {
@@ -219,6 +231,10 @@ func encryptAndSave(body string, ttl int64, encryption encryption.EncryptionBack
 		log.Error("Secret too long")
 		return "", fmt.Errorf("secret too long")
 	}
+	if clientEncrypted && !isClientEncryptionEnvelope(body) {
+		log.Error("Invalid client encryption envelope")
+		return "", fmt.Errorf("invalid client encryption envelope")
+	}
 
 	// Encrypt the data
 	encryptedData, key, err := encryption.Encrypt([]byte(body))
@@ -227,12 +243,61 @@ func encryptAndSave(body string, ttl int64, encryption encryption.EncryptionBack
 	}
 
 	// Store the encrypted data
-	id, err := storage.Store(encryptedData, key, ttl)
+	id, err := storage.Store(encryptedData, key, ttl, clientEncrypted)
 	if err != nil {
 		return "", err
 	}
 
 	return id.String(), nil
+}
+
+type clientEncryptionEnvelope struct {
+	Version    int    `json:"v"`
+	KDF        string `json:"k"`
+	Iterations int    `json:"i"`
+	Salt       string `json:"s"`
+	Cipher     string `json:"c"`
+	Nonce      string `json:"n"`
+	Data       string `json:"d"`
+}
+
+// isClientEncryptionEnvelope strictly recognizes the current browser format.
+// New secrets carry an explicit storage marker; this parser is also the
+// temporary fallback for Web Crypto links created before that marker existed.
+func isClientEncryptionEnvelope(body string) bool {
+	if !strings.HasPrefix(body, CLIENT_ENCRYPTION_PREFIX) {
+		return false
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(strings.TrimPrefix(body, CLIENT_ENCRYPTION_PREFIX)))
+	decoder.DisallowUnknownFields()
+
+	var envelope clientEncryptionEnvelope
+	if err := decoder.Decode(&envelope); err != nil {
+		return false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return false
+	}
+
+	if envelope.Version != 2 ||
+		envelope.KDF != "PBKDF2-SHA-256" ||
+		envelope.Iterations != CLIENT_ENCRYPTION_ITERATIONS ||
+		envelope.Cipher != "AES-256-GCM" {
+		return false
+	}
+
+	salt, err := base64.RawURLEncoding.DecodeString(envelope.Salt)
+	if err != nil || len(salt) != 16 {
+		return false
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(envelope.Nonce)
+	if err != nil || len(nonce) != 12 {
+		return false
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(envelope.Data)
+	return err == nil && len(ciphertext) >= 16
 }
 
 func getOtherLanguage(language string) string {

--- a/app_test.go
+++ b/app_test.go
@@ -99,10 +99,15 @@ func TestCreateAppRendersVersionedClientEncryption(t *testing.T) {
 		`const ENVELOPE_PREFIX = "emc:v2:"`,
 		`const PBKDF2_ITERATIONS = 600000`,
 		`name: "AES-GCM"`,
-		`const decryptLegacy`,
+		`client_encrypted: clientEncrypted`,
 	} {
 		if !strings.Contains(page, expected) {
 			t.Errorf("CreateApp() GET / did not render %q", expected)
+		}
+	}
+	for _, removed := range []string{"CryptoJS", "decryptLegacy", "looksLikeLegacyEnvelope"} {
+		if strings.Contains(page, removed) {
+			t.Errorf("CreateApp() GET / still rendered removed legacy code %q", removed)
 		}
 	}
 }
@@ -122,8 +127,12 @@ func TestCreateAppRendersLocalizedDecryptionError(t *testing.T) {
 		t.Fatalf("reading French view response: %v", err)
 	}
 
-	if !strings.Contains(string(body), "Le mot de passe est incorrect ou le message chiffré est endommagé.") {
+	page := string(body)
+	if !strings.Contains(page, "Le mot de passe est incorrect ou le message chiffré est endommagé.") {
 		t.Error("CreateApp() did not render the localized decryption error")
+	}
+	if !strings.Contains(page, "Ce message a été chiffré avec un mot de passe additionnel.") {
+		t.Error("CreateApp() did not render the localized encrypted-message notice")
 	}
 }
 
@@ -319,6 +328,9 @@ func TestCreateAppGetViewWithValidUUID(t *testing.T) {
 	if !strings.Contains(string(body), "confirm-div") {
 		t.Errorf("CreateApp() GET /en/view/00000000-0000-0000-0000-000000000000 = %v, want %v", string(body), "confirm-div")
 	}
+	if !strings.Contains(string(body), `id="decrypt-controls" class="d-none"`) {
+		t.Error("CreateApp() view page did not hide password controls by default")
+	}
 }
 
 func TestCreateAppGetDecryptWithIvalidUUID(t *testing.T) {
@@ -340,7 +352,7 @@ func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 	backend := &storage.InMemoryStorageBackend{}
 	backend.Init(map[string]string{})
 
-	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix(), false)
 
 	app := CreateApp(&encryption.NullEncryption{}, backend)
 
@@ -354,8 +366,9 @@ func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 
 	//Check if the body contains the right JSON response
-	if !strings.Contains(string(body), `{"body":"test"}`) {
-		t.Errorf("CreateApp() GET /decrypt/valid-uuid = %v, want %v", string(body), `{"body":"test"}`)
+	if !strings.Contains(string(body), `"body":"test"`) ||
+		!strings.Contains(string(body), `"client_encrypted":false`) {
+		t.Errorf("CreateApp() GET /decrypt/valid-uuid returned unexpected body: %s", body)
 	}
 
 	// Check if the data was deleted from the storage backend
@@ -372,7 +385,7 @@ func TestCreateAppConcurrentDecryptHasExactlyOneWinner(t *testing.T) {
 	if err := backend.Init(map[string]string{}); err != nil {
 		t.Fatalf("Init() failed: %v", err)
 	}
-	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix(), false)
 	if err != nil {
 		t.Fatalf("Store() failed: %v", err)
 	}
@@ -421,7 +434,7 @@ func TestCreateAppReleasesClaimAfterDecryptionFailure(t *testing.T) {
 	if err := backend.Init(map[string]string{}); err != nil {
 		t.Fatalf("Init() failed: %v", err)
 	}
-	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix(), false)
 	if err != nil {
 		t.Fatalf("Store() failed: %v", err)
 	}
@@ -462,7 +475,7 @@ func TestCreateAppDeleteValidUUID(t *testing.T) {
 	backend := &storage.InMemoryStorageBackend{}
 	backend.Init(map[string]string{})
 
-	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("test"), []byte("test"), time.Now().Add(time.Hour).Unix(), false)
 
 	app := CreateApp(&encryption.NullEncryption{}, backend)
 
@@ -507,6 +520,99 @@ func TestCreateAppPostEncrypt(t *testing.T) {
 	//Check if the body contains a UUID id
 	if !strings.Contains(string(body), `"id":"`) {
 		t.Errorf("CreateApp() POST /encrypt = %v, want %v", string(body), `"id":"`)
+	}
+}
+
+func TestCreateAppDecryptUsesStoredClientEncryptionMarker(t *testing.T) {
+	t.Parallel()
+
+	const envelope = `emc:v2:{"v":2,"k":"PBKDF2-SHA-256","i":600000,"s":"AAAAAAAAAAAAAAAAAAAAAA","c":"AES-256-GCM","n":"AAAAAAAAAAAAAAAA","d":"AAAAAAAAAAAAAAAAAAAAAA"}`
+
+	tests := []struct {
+		name            string
+		body            string
+		clientEncrypted bool
+	}{
+		{
+			name:            "encrypted envelope",
+			body:            envelope,
+			clientEncrypted: true,
+		},
+		{
+			name:            "plaintext that resembles an envelope",
+			body:            envelope,
+			clientEncrypted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &storage.InMemoryStorageBackend{}
+			if err := backend.Init(map[string]string{}); err != nil {
+				t.Fatalf("Init() failed: %v", err)
+			}
+			id, err := backend.Store([]byte(tt.body), nil, time.Now().Add(time.Hour).Unix(), tt.clientEncrypted)
+			if err != nil {
+				t.Fatalf("Store() failed: %v", err)
+			}
+
+			app := CreateApp(&encryption.NullEncryption{}, backend)
+			resp, err := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+			if err != nil {
+				t.Fatalf("GET /decrypt failed: %v", err)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("reading response: %v", err)
+			}
+			want := fmt.Sprintf(`"client_encrypted":%t`, tt.clientEncrypted)
+			if !strings.Contains(string(body), want) {
+				t.Fatalf("GET /decrypt response = %s, want %s", body, want)
+			}
+		})
+	}
+}
+
+func TestClientEncryptionEnvelopeDetection(t *testing.T) {
+	t.Parallel()
+
+	const valid = `emc:v2:{"v":2,"k":"PBKDF2-SHA-256","i":600000,"s":"AAAAAAAAAAAAAAAAAAAAAA","c":"AES-256-GCM","n":"AAAAAAAAAAAAAAAA","d":"AAAAAAAAAAAAAAAAAAAAAA"}`
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "valid current envelope", body: valid, want: true},
+		{name: "prefix only", body: CLIENT_ENCRYPTION_PREFIX, want: false},
+		{name: "wrong iterations", body: strings.Replace(valid, "600000", "128", 1), want: false},
+		{name: "unknown field", body: strings.Replace(valid, `"v":2`, `"v":2,"extra":true`, 1), want: false},
+		{name: "legacy CryptoJS payload", body: strings.Repeat("a", 64) + "Zm9v", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isClientEncryptionEnvelope(tt.body); got != tt.want {
+				t.Fatalf("isClientEncryptionEnvelope() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateAppRejectsInvalidMarkedClientEnvelope(t *testing.T) {
+	t.Parallel()
+
+	app := CreateApp(&encryption.NullEncryption{}, &storage.NullBackend{})
+	ttl := fmt.Sprint(time.Now().Add(time.Hour).Unix())
+	req := httptest.NewRequest(
+		"POST",
+		"/encrypt",
+		strings.NewReader(`{"body":"not-an-envelope","client_encrypted":true,"ttl":`+ttl+`}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Fatalf("POST /encrypt status = %d, want %d", resp.StatusCode, fiber.StatusBadRequest)
 	}
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -30,7 +30,7 @@
     "Your secret does not exist": "",
     "Either the link is wrong or the secret has expired.": "",
     "This message is for you:": "",
-    "It looks like your message has been encrypted with an additional password. Please enter it below to fully decrypt the message.": "",
+    "This message was encrypted with an additional password. Please enter it below to fully decrypt the message.": "",
     "Decrypt message with password": "",
     "The password is incorrect, or the encrypted message is damaged.": "",
     "Unable to create the secret link. Please try again.": "",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -30,7 +30,7 @@
     "Your secret does not exist": "Votre secret n'existe pas",
     "Either the link is wrong or the secret has expired.": "Soit le lien est erroné, soit le secret a expiré.",
     "This message is for you:": "Ce message est pour vous:",
-    "It looks like your message has been encrypted with an additional password. Please enter it below to fully decrypt the message.": "Il semble que votre message ait été crypté avec un code additionnel mot de passe. Veuillez le saisir ci-dessous pour décrypter entièrement le message",
+    "This message was encrypted with an additional password. Please enter it below to fully decrypt the message.": "Ce message a été chiffré avec un mot de passe additionnel. Veuillez le saisir ci-dessous pour déchiffrer entièrement le message.",
     "Decrypt message with password": "Décrypter le message avec un mot de passe",
     "The password is incorrect, or the encrypted message is damaged.": "Le mot de passe est incorrect ou le message chiffré est endommagé.",
     "Unable to create the secret link. Please try again.": "Impossible de créer le lien secret. Veuillez réessayer.",

--- a/storage/dynamodb.go
+++ b/storage/dynamodb.go
@@ -15,12 +15,13 @@ import (
 )
 
 type Record struct {
-	ID         string `dynamodbav:"id"`
-	Data       []byte `dynamodbav:"data"`
-	Key        []byte `dynamodbav:"key"`
-	TTL        int64  `dynamodbav:"ttl"`
-	ClaimToken string `dynamodbav:"claim_token,omitempty"`
-	ClaimUntil int64  `dynamodbav:"claim_until,omitempty"`
+	ID              string `dynamodbav:"id"`
+	Data            []byte `dynamodbav:"data"`
+	Key             []byte `dynamodbav:"key"`
+	TTL             int64  `dynamodbav:"ttl"`
+	ClaimToken      string `dynamodbav:"claim_token,omitempty"`
+	ClaimUntil      int64  `dynamodbav:"claim_until,omitempty"`
+	ClientEncrypted *bool  `dynamodbav:"client_encrypted,omitempty"`
 }
 
 type DynamoDBBackend struct {
@@ -96,14 +97,15 @@ func (b *DynamoDBBackend) Init(c map[string]string) error {
 	return nil
 }
 
-func (b *DynamoDBBackend) Store(data, key []byte, ttl int64) (uuid.UUID, error) {
+func (b *DynamoDBBackend) Store(data, key []byte, ttl int64, clientEncrypted bool) (uuid.UUID, error) {
 	id := uuid.New()
 
 	record := Record{
-		ID:   id.String(),
-		Data: data,
-		Key:  key,
-		TTL:  ttl,
+		ID:              id.String(),
+		Data:            data,
+		Key:             key,
+		TTL:             ttl,
+		ClientEncrypted: &clientEncrypted,
 	}
 
 	av, err := attributevalue.MarshalMap(record)
@@ -172,7 +174,12 @@ func (b *DynamoDBBackend) Claim(id uuid.UUID, lease time.Duration) (ClaimedSecre
 		return ClaimedSecret{}, err
 	}
 
-	return ClaimedSecret{Data: r.Data, Key: r.Key, Token: token}, nil
+	return ClaimedSecret{
+		Data:            r.Data,
+		Key:             r.Key,
+		Token:           token,
+		ClientEncrypted: r.ClientEncrypted,
+	}, nil
 }
 
 // Consume permanently deletes a secret if the caller still owns an active claim.

--- a/storage/dynamodb_test.go
+++ b/storage/dynamodb_test.go
@@ -127,7 +127,7 @@ func TestDynamoDBBackendStore(t *testing.T) {
 		"table_name": "secrets",
 	})
 
-	id, err := backend.Store([]byte("test"), []byte("test"), 1000)
+	id, err := backend.Store([]byte("test"), []byte("test"), 1000, false)
 
 	if err != nil {
 		t.Errorf("DynamoDBBackend.Store() failed: %s", err)
@@ -149,7 +149,7 @@ func TestDynamoDBBackendClaimAndConsume(t *testing.T) {
 		"table_name": "secrets",
 	})
 
-	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix(), true)
 
 	if err != nil {
 		t.Errorf("DynamoDBBackend.Store() failed: %s", err)
@@ -167,6 +167,9 @@ func TestDynamoDBBackendClaimAndConsume(t *testing.T) {
 
 	if string(claim.Key) != "key" {
 		t.Errorf("DynamoDBBackend.Claim() returned the wrong key")
+	}
+	if claim.ClientEncrypted == nil || !*claim.ClientEncrypted {
+		t.Errorf("DynamoDBBackend.Claim() did not preserve client encryption metadata")
 	}
 
 	if err := backend.Consume(id, claim.Token); err != nil {
@@ -188,7 +191,7 @@ func TestDynamoDBBackendClaimWithTTLInPast(t *testing.T) {
 		"table_name": "secrets",
 	})
 
-	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(-time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(-time.Hour).Unix(), false)
 
 	if err != nil {
 		t.Errorf("DynamoDBBackend.Store() failed: %s", err)
@@ -210,7 +213,7 @@ func TestDynamoDBBackendConcurrentClaimsHaveExactlyOneWinner(t *testing.T) {
 		"region":     "ca-central-1",
 		"table_name": "secrets",
 	})
-	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 	if err != nil {
 		t.Fatalf("Store() failed: %v", err)
 	}
@@ -260,7 +263,7 @@ func TestDynamoDBBackendReleaseAllowsRetry(t *testing.T) {
 		"region":     "ca-central-1",
 		"table_name": "secrets",
 	})
-	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("test"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 	if err != nil {
 		t.Fatalf("Store() failed: %v", err)
 	}

--- a/storage/in_memory.go
+++ b/storage/in_memory.go
@@ -9,11 +9,12 @@ import (
 )
 
 type pair struct {
-	Data       []byte
-	Key        []byte
-	TTL        int64
-	ClaimToken uuid.UUID
-	ClaimUntil time.Time
+	Data            []byte
+	Key             []byte
+	TTL             int64
+	ClaimToken      uuid.UUID
+	ClaimUntil      time.Time
+	ClientEncrypted *bool
 }
 
 // InMemoryStorageBackend is a storage backend that stores data in memory
@@ -70,12 +71,12 @@ func (b *InMemoryStorageBackend) size() int {
 }
 
 // Store stores data in the storage backend
-func (b *InMemoryStorageBackend) Store(data, key []byte, TTL int64) (uuid.UUID, error) {
+func (b *InMemoryStorageBackend) Store(data, key []byte, TTL int64, clientEncrypted bool) (uuid.UUID, error) {
 	b.m.Lock()
 	defer b.m.Unlock()
 
 	id := uuid.New()
-	b.data[id] = pair{Data: data, Key: key, TTL: TTL}
+	b.data[id] = pair{Data: data, Key: key, TTL: TTL, ClientEncrypted: &clientEncrypted}
 	return id, nil
 }
 
@@ -109,10 +110,20 @@ func (b *InMemoryStorageBackend) Claim(id uuid.UUID, lease time.Duration) (Claim
 	b.data[id] = secret
 
 	return ClaimedSecret{
-		Data:  append([]byte(nil), secret.Data...),
-		Key:   append([]byte(nil), secret.Key...),
-		Token: token,
+		Data:            append([]byte(nil), secret.Data...),
+		Key:             append([]byte(nil), secret.Key...),
+		Token:           token,
+		ClientEncrypted: cloneBool(secret.ClientEncrypted),
 	}, nil
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+
+	copy := *value
+	return &copy
 }
 
 // Consume permanently deletes a secret if the caller still owns its claim.

--- a/storage/in_memory_test.go
+++ b/storage/in_memory_test.go
@@ -26,7 +26,7 @@ func TestDelete(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 	if err := backend.Delete(id); err != nil {
 		t.Fatalf("Delete() failed: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestPurge(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	_, _ = backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
+	_, _ = backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix(), false)
 	if err := backend.purge(); err != nil {
 		t.Fatalf("purge() failed: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestStore(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, err := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, err := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 	if err != nil {
 		t.Fatalf("Store() failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestClaimAndConsume(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), true)
 
 	claim, err := backend.Claim(id, testClaimLease)
 	if err != nil {
@@ -83,6 +83,9 @@ func TestClaimAndConsume(t *testing.T) {
 	}
 	if string(claim.Data) != "data" || string(claim.Key) != "key" || claim.Token == uuid.Nil {
 		t.Fatalf("Claim() returned an invalid claim: %#v", claim)
+	}
+	if claim.ClientEncrypted == nil || !*claim.ClientEncrypted {
+		t.Fatalf("Claim() did not preserve client encryption metadata: %#v", claim)
 	}
 
 	if err := backend.Consume(id, claim.Token); err != nil {
@@ -97,7 +100,7 @@ func TestClaimExpiredOrMissingSecret(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(-time.Hour).Unix(), false)
 
 	for _, testID := range []uuid.UUID{id, uuid.New()} {
 		if _, err := backend.Claim(testID, testClaimLease); !errors.Is(err, ErrSecretUnavailable) {
@@ -110,7 +113,7 @@ func TestConcurrentClaimsHaveExactlyOneWinner(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 
 	const contenders = 32
 	start := make(chan struct{})
@@ -152,7 +155,7 @@ func TestReleaseAllowsImmediateRetry(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 
 	first, err := backend.Claim(id, testClaimLease)
 	if err != nil {
@@ -175,7 +178,7 @@ func TestExpiredClaimCanBeReclaimed(t *testing.T) {
 	t.Parallel()
 
 	backend := newInMemoryBackend(t)
-	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix())
+	id, _ := backend.Store([]byte("data"), []byte("key"), time.Now().Add(time.Hour).Unix(), false)
 
 	first, err := backend.Claim(id, 10*time.Millisecond)
 	if err != nil {

--- a/storage/null.go
+++ b/storage/null.go
@@ -26,7 +26,7 @@ func (b *NullBackend) Init(map[string]string) error {
 	return nil
 }
 
-func (b *NullBackend) Store(data, key []byte, ttl int64) (uuid.UUID, error) {
+func (b *NullBackend) Store(data, key []byte, ttl int64, clientEncrypted bool) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
 

--- a/storage/null_test.go
+++ b/storage/null_test.go
@@ -34,7 +34,7 @@ func TestNullBackendStore(t *testing.T) {
 	backend := NullBackend{}
 	data := []byte("hello world")
 	key := []byte("key")
-	_, err := backend.Store(data, key, 0)
+	_, err := backend.Store(data, key, 0, false)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}

--- a/storage/storage_backend.go
+++ b/storage/storage_backend.go
@@ -13,9 +13,10 @@ var (
 )
 
 type ClaimedSecret struct {
-	Data  []byte
-	Key   []byte
-	Token uuid.UUID
+	Data            []byte
+	Key             []byte
+	Token           uuid.UUID
+	ClientEncrypted *bool
 }
 
 type StorageBackend interface {
@@ -24,5 +25,5 @@ type StorageBackend interface {
 	Delete(id uuid.UUID) error
 	Init(map[string]string) error
 	Release(id, token uuid.UUID) error
-	Store(data, key []byte, ttl int64) (uuid.UUID, error)
+	Store(data, key []byte, ttl int64, clientEncrypted bool) (uuid.UUID, error)
 }

--- a/views/js.html
+++ b/views/js.html
@@ -1,9 +1,3 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/aes.js"
-    integrity="sha384-YkYpnhy3j3+zc3fQvzlbh4WGwDgt+06gsGsaApwM1O3IKIsKJk61C0Lr6YvbovUV"
-    crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/pbkdf2.js"
-    integrity="sha384-3TpUaoUrOhYmfB7OZ8ul4rKMr/NQRp2wiO+NtwbnXVaGIY/kv3Inu846n0P+AKwU"
-    crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"
     integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT"
     crossorigin="anonymous"></script>
@@ -13,11 +7,6 @@
     const lang = "{{.Lang}}";
     const viewId = "{{.ViewId}}";
     const requireAdditionalPassword = {{if .RequireAdditionalPassword}}true{{else}}false{{end}};
-
-    // Keep these constants only while links created by the legacy CryptoJS
-    // implementation can still exist.
-    const LEGACY_KEY_SIZE = 256;
-    const LEGACY_ITERATIONS = 128;
 
     const ENVELOPE_PREFIX = "emc:v2:";
     const PBKDF2_ITERATIONS = 600000;
@@ -35,23 +24,6 @@
         let sec = `${a.getSeconds()}`.padStart(2, "0")
         return year + '-' + month + '-' + date + ' ' + hour + ':' + min + ':' + sec;
     }
-
-    const decryptLegacy = (secret, password) => {
-        let salt = CryptoJS.enc.Hex.parse(secret.substr(0, 32));
-        let iv = CryptoJS.enc.Hex.parse(secret.substr(32, 32));
-        let encryptedMessage = secret.substring(64);
-        let key = CryptoJS.PBKDF2(password, salt, {
-            keySize: LEGACY_KEY_SIZE / 32,
-            iterations: LEGACY_ITERATIONS,
-        });
-
-        let decryptedMessage = CryptoJS.AES.decrypt(encryptedMessage, key, {
-            iv: iv,
-            padding: CryptoJS.pad.Pkcs7,
-            mode: CryptoJS.mode.CBC,
-        });
-        return decryptedMessage.toString(CryptoJS.enc.Utf8);
-    };
 
     const bytesToBase64Url = (bytes) => {
         let binary = "";
@@ -129,12 +101,18 @@
         return ENVELOPE_PREFIX + JSON.stringify(envelope);
     };
 
-    const decryptV2 = async (secret, password) => {
+    const parseV2Envelope = (secret) => {
+        if (typeof secret !== "string" || !secret.startsWith(ENVELOPE_PREFIX)) {
+            throw new Error("Unsupported encrypted message format");
+        }
+
         const envelope = JSON.parse(secret.substring(ENVELOPE_PREFIX.length));
+        const fields = Object.keys(envelope).sort().join(",");
 
         // Requiring this version's exact bounded parameters prevents a crafted
         // message from requesting an excessive amount of browser work.
         if (
+            fields !== "c,d,i,k,n,s,v" ||
             envelope.v !== 2 ||
             envelope.k !== "PBKDF2-SHA-256" ||
             envelope.i !== PBKDF2_ITERATIONS ||
@@ -151,6 +129,12 @@
             throw new Error("Invalid encrypted message parameters");
         }
 
+        return { salt, nonce, ciphertext };
+    };
+
+    const decryptV2 = async (secret, password) => {
+        const { salt, nonce, ciphertext } = parseV2Envelope(secret);
+
         const key = await deriveEncryptionKey(password, salt, ["decrypt"]);
         const plaintext = await crypto.subtle.decrypt(
             {
@@ -163,27 +147,6 @@
         );
 
         return new TextDecoder("utf-8", { fatal: true }).decode(plaintext);
-    };
-
-    const isV2Envelope = (secret) => secret.startsWith(ENVELOPE_PREFIX);
-
-    const looksLikeLegacyEnvelope = (secret) => {
-        return secret.length > 64 &&
-            /^[0-9a-fA-F]{64}/.test(secret) &&
-            /^[A-Za-z0-9+/]+={0,2}$/.test(secret.substring(64));
-    };
-
-    const decrypt = async (secret, password) => {
-        if (isV2Envelope(secret)) {
-            return decryptV2(secret, password);
-        }
-
-        const result = decryptLegacy(secret, password);
-        if (result === "") {
-            throw new Error("Legacy decryption failed");
-        }
-
-        return result;
     };
 
     const showGenerateError = (message) => {
@@ -202,9 +165,11 @@
             async: true,
             success: function (data) {
                 retrievedSecret = data.body;
-                $("#secret").val(data.body)
-                if (isV2Envelope(data.body) || looksLikeLegacyEnvelope(data.body)) {
-                    $("#decrypt-warning").removeClass("d-none");
+                if (data.client_encrypted) {
+                    $("#secret").val("");
+                    $("#decrypt-controls").removeClass("d-none");
+                } else {
+                    $("#secret").val(data.body);
                 }
                 $("#confirm-div").toggleClass("d-none");
                 $("#secret-div").toggleClass("d-none");
@@ -216,14 +181,14 @@
         });
     }
 
-    const submitEncryption = (body, ttl) => {
+    const submitEncryption = (body, ttl, clientEncrypted) => {
         $.ajax({
             type: "POST",
             url: "/encrypt",
             dataType: "json",
             async: true,
             contentType: "application/json",
-            data: JSON.stringify({ body: body, ttl: ttl }),
+            data: JSON.stringify({ body: body, ttl: ttl, client_encrypted: clientEncrypted }),
             success: function (data) {
                 $("#link").val(`${baseUrl}/${lang}/view/${data.id}`);
                 $("#link").prop("readonly", true);
@@ -262,8 +227,10 @@
         $("#decrypt-btn").prop("disabled", true).addClass("bg-opacity-20");
 
         try {
-            const result = await decrypt(retrievedSecret || $("#secret").val(), password);
+            const result = await decryptV2(retrievedSecret, password);
             $("#secret").val(result);
+            retrievedSecret = "";
+            $("#decrypt-controls").addClass("d-none");
         } catch (error) {
             $("#decrypt-error").removeClass("d-none");
         } finally {
@@ -292,7 +259,8 @@
         $("#expires-in").text(dateFormat(ttl))
 
         try {
-            const secret = password !== ""
+            const clientEncrypted = password !== "";
+            const secret = clientEncrypted
                 ? await encrypt($("#secret").val(), password)
                 : $("#secret").val();
 
@@ -301,7 +269,7 @@
                 return;
             }
 
-            submitEncryption(secret, ttl);
+            submitEncryption(secret, ttl, clientEncrypted);
         } catch (error) {
             showGenerateError("{{t `Unable to encrypt the secret. Please try again.` .Lang }}");
         }

--- a/views/view.html
+++ b/views/view.html
@@ -20,20 +20,21 @@
     <h4 class="mb-400">{{ t `This message is for you:` .Lang}}</h4>
     <p class="mb-400">{{ t `Careful: We will only show it once.` .Lang}}</p>
     <gcds-textarea textarea-id="secret"></gcds-textarea>
-    <gcds-container id="decrypt-warning" class="d-none" size="md">
-        <span class="font-bold">{{ t `Attention` .Lang}}:&nbsp;</span>
-        <span>{{ t `It looks like your message has been encrypted with an additional password. Please enter it below to
-            fully
-            decrypt the message.` .Lang}}</span>
-    </gcds-container>
-    <gcds-fieldset fieldset-id="fieldset" class="mt-400">
-        <gcds-input input-id="optional_pass" name="optional_pass" type="password"
-            label="{{t `Optional password` .Lang }}" placeholder="{{ t `Password` .Lang }}">
-        </gcds-input>
-    </gcds-fieldset>
-    <gcds-button id="decrypt-btn">
-        {{ t `Decrypt message with password` .Lang}}
-    </gcds-button>
-    <p id="decrypt-error" class="d-none text-danger mt-300" role="alert">
-        {{ t `The password is incorrect, or the encrypted message is damaged.` .Lang}}
-    </p></gcds-container>
+    <div id="decrypt-controls" class="d-none">
+        <gcds-container size="md">
+            <span class="font-bold">{{ t `Attention` .Lang}}:&nbsp;</span>
+            <span>{{ t `This message was encrypted with an additional password. Please enter it below to fully decrypt the message.` .Lang}}</span>
+        </gcds-container>
+        <gcds-fieldset fieldset-id="fieldset" class="mt-400">
+            <gcds-input input-id="optional_pass" name="optional_pass" type="password"
+                label="{{t `Password` .Lang }}" placeholder="{{ t `Password` .Lang }}">
+            </gcds-input>
+        </gcds-fieldset>
+        <gcds-button id="decrypt-btn">
+            {{ t `Decrypt message with password` .Lang}}
+        </gcds-button>
+        <p id="decrypt-error" class="d-none text-danger mt-300" role="alert">
+            {{ t `The password is incorrect, or the encrypted message is damaged.` .Lang}}
+        </p>
+    </div>
+</gcds-container>


### PR DESCRIPTION
This pull request introduces explicit support for tracking and handling client-side encrypted messages, removes legacy CryptoJS AES-CBC support, and updates both backend and frontend logic to improve security and user experience. The main changes include adding a `client_encrypted` marker to stored records, stricter envelope validation, and updating tests and localization strings accordingly.

**Client-side encryption handling:**
- Introduced a `client_encrypted` flag to the API and storage layer (`Record` struct, DynamoDB, and in-memory backends) to explicitly track whether a message was encrypted in the browser. This ensures password controls only appear when needed and prevents accidental plaintext from being misclassified. [[1]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2R24) [[2]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L99-R108) [[3]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L175-R182) [[4]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR156-R163) [[5]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR194) [[6]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL193-R205) [[7]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL209-R221) [[8]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR234-R237) [[9]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL230-R302)
- Added strict validation for the client encryption envelope in the backend, rejecting malformed or legacy payloads when the `client_encrypted` flag is set. [[1]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL230-R302) [[2]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR526-R618)

**Removal of legacy encryption support:**
- Dropped support for decrypting messages encrypted with the old CryptoJS AES-CBC format, both in backend logic and frontend rendering. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[2]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL102-R112)

**Test and validation improvements:**
- Updated and expanded unit tests to verify correct handling of the `client_encrypted` flag, envelope validation, and removal of legacy code. [[1]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL102-R112) [[2]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL125-R136) [[3]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR331-R333) [[4]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL343-R355) [[5]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL357-R371) [[6]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL375-R388) [[7]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL424-R437) [[8]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL465-R478) [[9]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR526-R618) [[10]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L130-R130) [[11]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L152-R152) [[12]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3R171-R173)

**Localization and UI updates:**
- Improved the user-facing messaging and localization for password-protected messages, clarifying when an additional password is required. [[1]](diffhunk://#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7L33-R33) [[2]](diffhunk://#diff-86d23a5be9d54f3c756b91e0d6412ac8bbbb232600ab2ee5554ca46079b4f1e6L33-R33)

**Code and API consistency:**
- Updated API method signatures and internal logic to consistently pass and handle the new `client_encrypted` parameter. [[1]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dR24-R25) [[2]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL209-R221) [[3]](diffhunk://#diff-d8427bc97b5d9752278d238998f0bc0596fdb28eaa5a84849cb9f7b81dc97ff2L99-R108) [[4]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L130-R130) [[5]](diffhunk://#diff-82bebb315e54653ac1a8fdfffc96a3bb2f3226a003007138979210bbf0130db3L152-R152)

These changes collectively improve security, clarity, and maintainability for handling encrypted messages in the application.