### PR TITLE
feat: switch from get to post

### DIFF
--- a/app.go
+++ b/app.go
@@ -113,7 +113,9 @@ Preferred-Languages: en, fr`
 		}, "base")
 	})
 
-	app.Get("/decrypt/:id", func(c *fiber.Ctx) error {
+	app.Post("/decrypt/:id", func(c *fiber.Ctx) error {
+		c.Set(fiber.HeaderCacheControl, "no-store, max-age=0")
+
 		//Convert the id to a UUID
 		id, err := uuid.Parse(c.Params("id"))
 		if err != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -328,25 +328,28 @@ func TestCreateAppGetViewWithValidUUID(t *testing.T) {
 	if !strings.Contains(string(body), "confirm-div") {
 		t.Errorf("CreateApp() GET /en/view/00000000-0000-0000-0000-000000000000 = %v, want %v", string(body), "confirm-div")
 	}
-	if !strings.Contains(string(body), `id="decrypt-controls" class="d-none"`) {
+	if !strings.Contains(string(body), `class="d-none" id="decrypt-div"`) {
 		t.Error("CreateApp() view page did not hide password controls by default")
 	}
 }
 
-func TestCreateAppGetDecryptWithIvalidUUID(t *testing.T) {
+func TestCreateAppPostDecryptWithInvalidUUID(t *testing.T) {
 	t.Parallel()
 
 	app := CreateApp(&encryption.NullEncryption{}, &storage.NullBackend{})
 
-	req := httptest.NewRequest("GET", "/decrypt/invalid-uuid", nil)
+	req := httptest.NewRequest("POST", "/decrypt/invalid-uuid", nil)
 	resp, _ := app.Test(req)
 
 	if resp.StatusCode != fiber.StatusBadRequest {
-		t.Errorf("CreateApp() GET /decrypt/invalid-uuid = %v, want %v", resp.StatusCode, fiber.StatusBadRequest)
+		t.Errorf("CreateApp() POST /decrypt/invalid-uuid = %v, want %v", resp.StatusCode, fiber.StatusBadRequest)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store, max-age=0" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store, max-age=0")
 	}
 }
 
-func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
+func TestCreateAppPostDecryptWithValidUUID(t *testing.T) {
 	t.Parallel()
 
 	backend := &storage.InMemoryStorageBackend{}
@@ -356,11 +359,14 @@ func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 
 	app := CreateApp(&encryption.NullEncryption{}, backend)
 
-	req := httptest.NewRequest("GET", "/decrypt/"+id.String(), nil)
+	req := httptest.NewRequest("POST", "/decrypt/"+id.String(), nil)
 	resp, _ := app.Test(req)
 
 	if resp.StatusCode != fiber.StatusOK {
-		t.Errorf("CreateApp() GET /decrypt/valid-uuid = %v, want %v", resp.StatusCode, fiber.StatusOK)
+		t.Errorf("CreateApp() POST /decrypt/valid-uuid = %v, want %v", resp.StatusCode, fiber.StatusOK)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store, max-age=0" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store, max-age=0")
 	}
 
 	body, _ := io.ReadAll(resp.Body)
@@ -368,13 +374,43 @@ func TestCreateAppGetDecryptWithValidUUID(t *testing.T) {
 	//Check if the body contains the right JSON response
 	if !strings.Contains(string(body), `"body":"test"`) ||
 		!strings.Contains(string(body), `"client_encrypted":false`) {
-		t.Errorf("CreateApp() GET /decrypt/valid-uuid returned unexpected body: %s", body)
+		t.Errorf("CreateApp() POST /decrypt/valid-uuid returned unexpected body: %s", body)
 	}
 
 	// Check if the data was deleted from the storage backend
 	_, err := backend.Claim(id, time.Minute)
 	if !errors.Is(err, storage.ErrSecretUnavailable) {
 		t.Errorf("Claim() after decrypt = %v, want ErrSecretUnavailable", err)
+	}
+}
+
+func TestCreateAppGetDoesNotRetrieveSecret(t *testing.T) {
+	t.Parallel()
+
+	backend := &storage.InMemoryStorageBackend{}
+	if err := backend.Init(map[string]string{}); err != nil {
+		t.Fatalf("Init() failed: %v", err)
+	}
+	id, err := backend.Store([]byte("test"), nil, time.Now().Add(time.Hour).Unix(), false)
+	if err != nil {
+		t.Fatalf("Store() failed: %v", err)
+	}
+
+	app := CreateApp(&encryption.NullEncryption{}, backend)
+	resp, err := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	if err != nil {
+		t.Fatalf("GET /decrypt returned an error: %v", err)
+	}
+	if resp.StatusCode == fiber.StatusOK {
+		t.Fatal("GET /decrypt unexpectedly retrieved the secret")
+	}
+
+	claim, err := backend.Claim(id, time.Minute)
+	if err != nil {
+		t.Fatalf("secret was consumed by GET /decrypt: %v", err)
+	}
+	if err := backend.Release(id, claim.Token); err != nil {
+		t.Fatalf("Release() failed: %v", err)
 	}
 }
 
@@ -402,10 +438,10 @@ func TestCreateAppConcurrentDecryptHasExactlyOneWinner(t *testing.T) {
 			defer wg.Done()
 			<-start
 
-			req := httptest.NewRequest("GET", "/decrypt/"+id.String(), nil)
+			req := httptest.NewRequest("POST", "/decrypt/"+id.String(), nil)
 			resp, requestErr := app.Test(req)
 			if requestErr != nil {
-				t.Errorf("GET /decrypt returned an error: %v", requestErr)
+				t.Errorf("POST /decrypt returned an error: %v", requestErr)
 				return
 			}
 			statuses <- resp.StatusCode
@@ -440,17 +476,17 @@ func TestCreateAppReleasesClaimAfterDecryptionFailure(t *testing.T) {
 	}
 
 	app := CreateApp(&failOnceEncryption{}, backend)
-	first, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	first, _ := app.Test(httptest.NewRequest("POST", "/decrypt/"+id.String(), nil))
 	if first.StatusCode != fiber.StatusBadRequest {
 		t.Fatalf("first decrypt status = %d, want %d", first.StatusCode, fiber.StatusBadRequest)
 	}
 
-	second, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	second, _ := app.Test(httptest.NewRequest("POST", "/decrypt/"+id.String(), nil))
 	if second.StatusCode != fiber.StatusOK {
 		t.Fatalf("retry decrypt status = %d, want %d", second.StatusCode, fiber.StatusOK)
 	}
 
-	third, _ := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+	third, _ := app.Test(httptest.NewRequest("POST", "/decrypt/"+id.String(), nil))
 	if third.StatusCode != fiber.StatusBadRequest {
 		t.Fatalf("decrypt after successful retry status = %d, want %d", third.StatusCode, fiber.StatusBadRequest)
 	}
@@ -557,9 +593,9 @@ func TestCreateAppDecryptUsesStoredClientEncryptionMarker(t *testing.T) {
 			}
 
 			app := CreateApp(&encryption.NullEncryption{}, backend)
-			resp, err := app.Test(httptest.NewRequest("GET", "/decrypt/"+id.String(), nil))
+			resp, err := app.Test(httptest.NewRequest("POST", "/decrypt/"+id.String(), nil))
 			if err != nil {
-				t.Fatalf("GET /decrypt failed: %v", err)
+				t.Fatalf("POST /decrypt failed: %v", err)
 			}
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -567,7 +603,7 @@ func TestCreateAppDecryptUsesStoredClientEncryptionMarker(t *testing.T) {
 			}
 			want := fmt.Sprintf(`"client_encrypted":%t`, tt.clientEncrypted)
 			if !strings.Contains(string(body), want) {
-				t.Fatalf("GET /decrypt response = %s, want %s", body, want)
+				t.Fatalf("POST /decrypt response = %s, want %s", body, want)
 			}
 		})
 	}

--- a/views/js.html
+++ b/views/js.html
@@ -160,23 +160,22 @@
 
     const retrieveEncryption = (id) => {
         $.ajax({
-            type: "GET",
+            type: "POST",
             url: `/decrypt/${id}`,
             async: true,
             success: function (data) {
                 retrievedSecret = data.body;
+                $("#confirm-div").addClass("d-none");
                 if (data.client_encrypted) {
-                    $("#secret").val("");
-                    $("#decrypt-controls").removeClass("d-none");
+                    $("#decrypt-div").removeClass("d-none");
                 } else {
                     $("#secret").val(data.body);
+                    $("#secret-div").removeClass("d-none");
                 }
-                $("#confirm-div").toggleClass("d-none");
-                $("#secret-div").toggleClass("d-none");
             },
             error: function () {
-                $("#confirm-div").toggleClass("d-none");
-                $("#404-div").toggleClass("d-none");
+                $("#confirm-div").addClass("d-none");
+                $("#404-div").removeClass("d-none");
             }
         });
     }
@@ -230,7 +229,8 @@
             const result = await decryptV2(retrievedSecret, password);
             $("#secret").val(result);
             retrievedSecret = "";
-            $("#decrypt-controls").addClass("d-none");
+            $("#decrypt-div").addClass("d-none");
+            $("#secret-div").removeClass("d-none");
         } catch (error) {
             $("#decrypt-error").removeClass("d-none");
         } finally {

--- a/views/view.html
+++ b/views/view.html
@@ -20,21 +20,22 @@
     <h4 class="mb-400">{{ t `This message is for you:` .Lang}}</h4>
     <p class="mb-400">{{ t `Careful: We will only show it once.` .Lang}}</p>
     <gcds-textarea textarea-id="secret"></gcds-textarea>
-    <div id="decrypt-controls" class="d-none">
-        <gcds-container size="md">
-            <span class="font-bold">{{ t `Attention` .Lang}}:&nbsp;</span>
-            <span>{{ t `This message was encrypted with an additional password. Please enter it below to fully decrypt the message.` .Lang}}</span>
-        </gcds-container>
-        <gcds-fieldset fieldset-id="fieldset" class="mt-400">
-            <gcds-input input-id="optional_pass" name="optional_pass" type="password"
-                label="{{t `Password` .Lang }}" placeholder="{{ t `Password` .Lang }}">
-            </gcds-input>
-        </gcds-fieldset>
-        <gcds-button id="decrypt-btn">
-            {{ t `Decrypt message with password` .Lang}}
-        </gcds-button>
-        <p id="decrypt-error" class="d-none text-danger mt-300" role="alert">
-            {{ t `The password is incorrect, or the encrypted message is damaged.` .Lang}}
-        </p>
-    </div>
+</gcds-container>
+
+<gcds-container class="d-none" id="decrypt-div" size="lg" padding="400" margin="200" centered>
+    <gcds-container size="md">
+        <span class="font-bold">{{ t `Attention` .Lang}}:&nbsp;</span>
+        <span>{{ t `This message was encrypted with an additional password. Please enter it below to fully decrypt the message.` .Lang}}</span>
+    </gcds-container>
+    <gcds-fieldset fieldset-id="fieldset" class="mt-400">
+        <gcds-input input-id="optional_pass" name="optional_pass" type="password"
+            label="{{t `Password` .Lang }}" placeholder="{{ t `Password` .Lang }}">
+        </gcds-input>
+    </gcds-fieldset>
+    <gcds-button id="decrypt-btn">
+        {{ t `Decrypt message with password` .Lang}}
+    </gcds-button>
+    <p id="decrypt-error" class="d-none text-danger mt-300" role="alert">
+        {{ t `The password is incorrect, or the encrypted message is damaged.` .Lang}}
+    </p>
 </gcds-container>


### PR DESCRIPTION
This pull request refactors the decryption endpoint to use `POST` instead of `GET`, improves security by adding cache control headers, and updates both the frontend and tests to match these changes. It also cleans up the UI and JavaScript logic for decrypting secrets, and ensures that secrets cannot be retrieved via `GET` requests anymore.

**API and Security Improvements:**

* Changed the `/decrypt/:id` endpoint from `GET` to `POST` to prevent secrets from being retrieved via URL and to improve security.
* Added a `Cache-Control: no-store, max-age=0` header to all `/decrypt/:id` responses to prevent sensitive data from being cached.

**Frontend and UI Updates:**

* Updated all AJAX calls in `views/js.html` to use `POST` for decryption, and improved UI logic to show/hide the correct elements (`decrypt-div`, `secret-div`, `404-div`) based on the decryption state. [[1]](diffhunk://#diff-f858aa19c3d58912681cb710ac6dfb6c5e8a0cbd525f419c46b3d2c1e9da1acaL163-R178) [[2]](diffhunk://#diff-f858aa19c3d58912681cb710ac6dfb6c5e8a0cbd525f419c46b3d2c1e9da1acaL233-R233)
* Refactored the view template to replace the old `decrypt-controls` div with a new `decrypt-div` container, and updated related IDs and classes for consistency. [[1]](diffhunk://#diff-2c13e0e9aeb12baf4f037e103f64ff57fee65f22ed2c34fe3321f4f08bc93c6aL23-R25) [[2]](diffhunk://#diff-2c13e0e9aeb12baf4f037e103f64ff57fee65f22ed2c34fe3321f4f08bc93c6aL39)

**Test Suite Updates:**

* Updated all tests to use `POST` for `/decrypt/:id`, added checks for the `Cache-Control` header, and added a new test to ensure secrets cannot be retrieved via `GET`. [[1]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL331-R352) [[2]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL359-R377) [[3]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eR387-R416) [[4]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL405-R444) [[5]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL443-R489) [[6]](diffhunk://#diff-65409e14d57dfeeef8ef8a499ca2eb193731e4a33b6ae6a83fc83eebef4e015eL560-R606)