### PR TITLE
fix: action permissions

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,10 @@
 on: [issues, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   sync-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_requests_lambda.yml
+++ b/.github/workflows/pull_requests_lambda.yml
@@ -3,6 +3,9 @@ name: "CI Lambda"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/security_scan_terraform.yml
+++ b/.github/workflows/security_scan_terraform.yml
@@ -10,7 +10,10 @@ on:
   pull_request:
     paths:
       - "aws/**"
-      - ".github/workflows/security_scan_terraform.yml" 
+      - ".github/workflows/security_scan_terraform.yml"
+
+permissions:
+  contents: read
 
 jobs:
   terraform-security-scan:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set permissions for improved security and clarity. The main changes involve adding the `permissions` field to workflows, granting only the minimum required access for each workflow.

**Workflow permissions updates:**

* [`.github/workflows/labels.yml`](diffhunk://#diff-09793c303182c720cf0b5b29c80723b396d6f87c1642fbb7e4f9fe48cbf4560dR2-R7): Added `permissions` specifying `contents: read`, `issues: write`, and `pull-requests: write` to restrict and clarify the workflow's access.
* [`.github/workflows/ci_docker.yml`](diffhunk://#diff-c5bffcf051c81d7aae7810472befaf41ffef2ad99c83d55c9678e346dc63f348R7-R9): Added `permissions: contents: read` to limit the workflow to read-only access to repository contents.
* [`.github/workflows/pull_requests_lambda.yml`](diffhunk://#diff-61e26b6a428b5c92149d2c7c48098ae6c40b1779c701cd29c9d9acd681d8029aR6-R8): Added `permissions: contents: read` to restrict workflow access to read-only.
* [`.github/workflows/security_scan_terraform.yml`](diffhunk://#diff-31ef916e98e12fc300fa036c72aa04daf4b42ff14480e4c599363909ca2c8a03R15-R17): Added `permissions: contents: read` for read-only access in the security scan workflow.

These changes follow GitHub's best practices for workflow security by granting only the permissions each workflow needs.